### PR TITLE
fix the QueryResponse structure to follow the expected structure

### DIFF
--- a/crates/ndc-sendgrid/src/query.rs
+++ b/crates/ndc-sendgrid/src/query.rs
@@ -4,6 +4,7 @@ use ndc_sdk::{
     connector::QueryError,
     models::{Argument, QueryRequest, QueryResponse, RowFieldValue, RowSet},
 };
+use serde_json::json;
 
 use super::configuration;
 use super::schema::LIST_TEMPLATES_FUNCTION_NAME;
@@ -86,11 +87,11 @@ pub async fn execute(
             let params = parse_list_templates_params(args)?;
             let response =
                 invoke_list_function_templates(http_client, &configuration.sendgrid_api_key, &params).await;
-
             match response {
                 Ok(list_response) => {
                     let result = serde_json::to_value(list_response.result)
                         .map_err(|err| QueryError::Other(Box::new(err)))?;
+                    let result = json!({"rows": result, "aggregates": null});
                     let response_row =
                         IndexMap::from([(String::from("__value"), RowFieldValue(result))]);
                     Ok(QueryResponse(vec![RowSet {

--- a/crates/ndc-sendgrid/src/sendgrid_api.rs
+++ b/crates/ndc-sendgrid/src/sendgrid_api.rs
@@ -226,7 +226,6 @@ pub async fn invoke_send_mail(
         .map_err(|err| RequestError::OtherError {
             error: err.to_string(),
         })?;
-
     match response.status() {
         StatusCode::ACCEPTED => Ok(()),
         StatusCode::BAD_REQUEST => {

--- a/crates/ndc-sendgrid/src/sendgrid_api.rs
+++ b/crates/ndc-sendgrid/src/sendgrid_api.rs
@@ -226,6 +226,7 @@ pub async fn invoke_send_mail(
         .map_err(|err| RequestError::OtherError {
             error: err.to_string(),
         })?;
+
     match response.status() {
         StatusCode::ACCEPTED => Ok(()),
         StatusCode::BAD_REQUEST => {


### PR DESCRIPTION
As per this [PR](https://github.com/hasura/v3-engine/pull/83), If a command has a selection set - the expected format is as follows:
```json
[
  {
    "rows": [
      {
        "__value": {
          "rows": [
            {
              <Object>
            }
          ]
        }
      }
    ]
  }
]
```

i.e the value of the function/procedure needs to be present in the `rows` field. This PR fixes that