### PR TITLE
Fix incorrect types used on unsubscription_settings

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,9 @@ name: Create and publish a Docker image
 
 # Configures this workflow to run every time a change is pushed to selected tags and branches
 on:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,3 +61,33 @@ jobs:
           name: connector-definition.tgz
           path: ./connector-definition/dist/connector-definition.tgz
           compression-level: 0 # Already compressed
+
+  release-connector:
+    name: Release connector
+    runs-on: ubuntu-latest
+    needs: build-and-push-image
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: connector-definition.tgz
+          path: ./connector-definition/dist/connector-definition.tgz
+      - name: Get version from tag
+        id: get-version
+        run: |
+          echo "tagged_version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+        shell: bash
+      - uses: mindsers/changelog-reader-action@v2
+        id: changelog-reader
+        with:
+          version: ${{ steps.get-version.outputs.tagged_version }}
+          path: ./CHANGELOG.md
+      - uses: softprops/action-gh-release@v1
+        with:
+          draft: false
+          tag_name: v${{ steps.get-version.outputs.tagged_version }}
+          body: ${{ steps.changelog-reader.outputs.changes }}
+          files: |
+            ./connector-definition/dist/connector-definition.tgz
+          fail_on_unmatched_files: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This changelog documents changes between release tags.
 
 Upcoming changes for the next versioned release.
 
+## v0.5
+* Fix incorrect types used on unsubscription_settings object type ([#9](https://github.com/hasura/ndc-sendgrid/pull/9))
+
 ## v0.4
 
 * Updated with the latest NDC SDK version that supports NDC Spec v0.1.0-rc.16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,33 +1,27 @@
 # SendGrid Connector Changelog
-
 This changelog documents changes between release tags.
 
 
-## main
-
+## [Unreleased]
 Upcoming changes for the next versioned release.
 
-## v0.5
+## [0.5] - 2024-02-28
 * Fix incorrect types used on unsubscription_settings object type ([#9](https://github.com/hasura/ndc-sendgrid/pull/9))
 
-## v0.4
-
+## [0.4] - 2024-02-21
 * Updated with the latest NDC SDK version that supports NDC Spec v0.1.0-rc.16
 * send_mail procedure now takes the full send mail request type and uses nested objects
 
-## v0.3
+## [0.3] - 2023-10-26
 * Simplified send_mail inputs to work around v3-engine missing argument object type support
 
-## v0.2
-
+## [0.2] - 2023-09-15
 Updates include:
 
 * Updating the Spec and SDK dependencies
 * Auth Support via `SERVICE_TOKEN_SECRET`
 
-
-## v0.1
-
+## [0.1] - 2023-09-14
 Initial releaase of SendGrid Connector.
 
 Supports:

--- a/crates/ndc-sendgrid/src/schema.rs
+++ b/crates/ndc-sendgrid/src/schema.rs
@@ -453,11 +453,11 @@ fn unsubscription_settings() -> ObjectType {
         description: Some(String::from("An object allowing you to specify how to handle unsubscribes.")),
         fields: BTreeMap::from([
             (String::from("group_id"), ObjectField {
-                r#type: named("String"),
+                r#type: named("Int"),
                 description: Some(String::from("The unsubscribe group to associate with this email."))
             }),
             (String::from("groups_to_display"), ObjectField {
-                r#type: nullable(array_of(named("group_id"))),
+                r#type: nullable(array_of(named("Int"))),
                 description: Some(String::from("An array containing the unsubscribe groups that you would like to be displayed on the unsubscribe preferences page."))
             }),
         ]),

--- a/crates/ndc-sendgrid/src/sendgrid_api.rs
+++ b/crates/ndc-sendgrid/src/sendgrid_api.rs
@@ -185,8 +185,8 @@ pub struct MailAttachment {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct UnsubscriptionSettings {
-    pub group_id: String,
-    pub groups_to_display: Option<Vec<String>>,
+    pub group_id: u32,
+    pub groups_to_display: Option<Vec<u32>>,
 }
 
 pub async fn invoke_list_function_templates(


### PR DESCRIPTION
Group ID types are [supposed to actually be integers](https://docs.sendgrid.com/api-reference/mail-send/mail-send):

![image](https://github.com/hasura/ndc-sendgrid/assets/1214352/24a7cbc9-fd04-483c-b7b6-8d262133df20)

This PR also adds to CI to enable automatic releases on tagged revisions.